### PR TITLE
Add caching and offline support for admin pages

### DIFF
--- a/backend/src/models/Problem.js
+++ b/backend/src/models/Problem.js
@@ -168,7 +168,7 @@ class Problem extends BaseModel {
   async search(searchTerm, options = {}) {
     try {
       const sql = `
-        SELECT 
+        SELECT
           p.*,
           d.name as device_name,
           d.brand as device_brand,
@@ -176,14 +176,14 @@ class Problem extends BaseModel {
           d.color as device_color,
           COUNT(DISTINCT ds.id) as steps_count,
           ts_rank(
-            to_tsvector('russian', p.title || ' ' || COALESCE(p.description, '')), 
+            to_tsvector('russian', COALESCE(p.title,'') || ' ' || COALESCE(p.description,'') || ' ' || COALESCE(d.name,'') || ' ' || COALESCE(d.brand,'') || ' ' || COALESCE(d.model,'')),
             plainto_tsquery('russian', $1)
           ) as rank
         FROM problems p
         LEFT JOIN devices d ON p.device_id = d.id
         LEFT JOIN diagnostic_steps ds ON p.id = ds.problem_id AND ds.is_active = true
         WHERE p.is_active = true
-          AND to_tsvector('russian', p.title || ' ' || COALESCE(p.description, ''))
+          AND to_tsvector('russian', COALESCE(p.title,'') || ' ' || COALESCE(p.description,'') || ' ' || COALESCE(d.name,'') || ' ' || COALESCE(d.brand,'') || ' ' || COALESCE(d.model,''))
               @@ plainto_tsquery('russian', $1)
         GROUP BY p.id, d.name, d.brand, d.model, d.color
         ORDER BY rank DESC, p.priority DESC

--- a/frontend/src/api/remotes.ts
+++ b/frontend/src/api/remotes.ts
@@ -1,4 +1,5 @@
-import { apiClient, handleApiError, createPaginatedRequest } from "./client";
+import { apiClient, handleApiError } from "./client";
+import { getCache, setCache, invalidateCache, buildKey } from "./cache";
 import type { Remote } from "@/types";
 
 // Типы для API
@@ -83,12 +84,15 @@ export interface RemoteStats {
  */
 export const remotesApi = {
   /**
-   * Получение списка пультов с пагинацией и фильтрами
+   * Получение списка пультов с пагинацией и фильтрами (кэшируется)
    */
   async getAll(filters: RemoteFilters = {}) {
     try {
-      const params = new URLSearchParams();
+      const key = buildKey("remotes:getAll", filters || {});
+      const cached = getCache<any>(key);
+      if (cached) return cached;
 
+      const params = new URLSearchParams();
       if (filters.page) params.append("page", filters.page.toString());
       if (filters.limit) params.append("limit", filters.limit.toString());
       if (filters.search) params.append("search", filters.search);
@@ -101,18 +105,25 @@ export const remotesApi = {
       const queryString = params.toString();
       const url = queryString ? `/remotes?${queryString}` : "/remotes";
 
-      return await apiClient.get(url);
+      const res = await apiClient.get(url);
+      setCache(key, res);
+      return res;
     } catch (error) {
       throw handleApiError(error, "Failed to fetch remotes");
     }
   },
 
   /**
-   * Получение пульта по ID
+   * Получение пульта по ID (кэшируется)
    */
   async getById(id: string): Promise<Remote> {
     try {
+      const key = `remotes:getById:${id}`;
+      const cached = getCache<any>(key);
+      if (cached) return cached?.data ?? cached;
+
       const response = await apiClient.get<any>(`/remotes/${id}`);
+      setCache(key, response);
       return response?.data ?? response;
     } catch (error) {
       throw handleApiError(error, `Failed to fetch remote ${id}`);
@@ -120,11 +131,12 @@ export const remotesApi = {
   },
 
   /**
-   * Создание нового пульта
+   * Создание нового пульта (инвалидирует кэш)
    */
   async create(data: RemoteCreateData): Promise<Remote> {
     try {
       const response = await apiClient.post("/remotes", data);
+      invalidateCache("remotes:");
       return response.data;
     } catch (error) {
       throw handleApiError(error, "Failed to create remote");
@@ -132,11 +144,12 @@ export const remotesApi = {
   },
 
   /**
-   * Обновление пульт��
+   * Обновление пульта (инвалидирует кэш)
    */
   async update(id: string, data: RemoteUpdateData): Promise<Remote> {
     try {
       const response = await apiClient.put(`/remotes/${id}`, data);
+      invalidateCache("remotes:");
       return response.data;
     } catch (error) {
       throw handleApiError(error, `Failed to update remote ${id}`);
@@ -144,11 +157,12 @@ export const remotesApi = {
   },
 
   /**
-   * Удаление пульта (мягкое удаление)
+   * Удаление пульта (мягкое удаление) (инвалидирует кэш)
    */
   async delete(id: string): Promise<Remote> {
     try {
       const response = await apiClient.delete(`/remotes/${id}`);
+      invalidateCache("remotes:");
       return response.data;
     } catch (error) {
       throw handleApiError(error, `Failed to delete remote ${id}`);
@@ -156,11 +170,16 @@ export const remotesApi = {
   },
 
   /**
-   * Получение пультов для конкретного устройства
+   * Получение пультов для конкретного устройства (кэшируется)
    */
   async getByDevice(deviceId: string): Promise<Remote[]> {
     try {
+      const key = `remotes:getByDevice:${deviceId}`;
+      const cached = getCache<any>(key);
+      if (cached) return cached?.data ?? cached;
+
       const response = await apiClient.get<any>(`/remotes/device/${deviceId}`);
+      setCache(key, response);
       return response?.data ?? response;
     } catch (error: any) {
       // Handle 404 gracefully - no remotes found for device
@@ -176,7 +195,7 @@ export const remotesApi = {
   },
 
   /**
-   * Получение пульта по умолчанию для устройства
+   * ��олучение пульта по умолчанию для устройства
    */
   async getDefaultForDevice(deviceId: string): Promise<Remote> {
     try {
@@ -200,11 +219,12 @@ export const remotesApi = {
   },
 
   /**
-   * У��тановка пульта как default для устройства
+   * Установка пульта как default для устройства (инвалидирует кэш)
    */
   async setAsDefault(remoteId: string, deviceId: string): Promise<void> {
     try {
       await apiClient.post(`/remotes/${remoteId}/set-default/${deviceId}`);
+      invalidateCache("remotes:");
     } catch (error) {
       throw handleApiError(
         error,
@@ -214,11 +234,12 @@ export const remotesApi = {
   },
 
   /**
-   * Дублирование пульта
+   * Дублирова��ие пульта (инвалидирует кэш)
    */
   async duplicate(id: string, data: RemoteDuplicateData = {}): Promise<Remote> {
     try {
       const response = await apiClient.post(`/remotes/${id}/duplicate`, data);
+      invalidateCache("remotes:");
       return response.data;
     } catch (error) {
       throw handleApiError(error, `Failed to duplicate remote ${id}`);
@@ -226,11 +247,12 @@ export const remotesApi = {
   },
 
   /**
-   * Инкремент счетчика использования
+   * Инкремент счетчика использования (инвалидирует кэш по id)
    */
   async incrementUsage(id: string): Promise<{ usage_count: number }> {
     try {
       const response = await apiClient.post(`/remotes/${id}/use`);
+      invalidateCache(`remotes:getById:${id}`);
       return response.data;
     } catch (error) {
       throw handleApiError(error, `Failed to increment usage for remote ${id}`);
@@ -238,14 +260,19 @@ export const remotesApi = {
   },
 
   /**
-   * Получение статистики использования пультов
+   * Получение статистики использования пультов (кэшируется)
    */
   async getStats(deviceId?: string): Promise<RemoteStats> {
     try {
+      const key = deviceId ? `remotes:stats:${deviceId}` : "remotes:stats:all";
+      const cached = getCache<any>(key);
+      if (cached) return cached?.data ?? cached;
+
       const url = deviceId
         ? `/remotes/stats?device_id=${deviceId}`
         : "/remotes/stats";
       const response = await apiClient.get(url);
+      setCache(key, response);
       return response.data;
     } catch (error) {
       throw handleApiError(error, "Failed to fetch remote stats");
@@ -253,7 +280,7 @@ export const remotesApi = {
   },
 
   /**
-   * Поиск пультов
+   * Поиск пультов (использует кэширование getAll)
    */
   async search(
     query: string,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,6 +32,8 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       refetchOnReconnect: "always",
       refetchInterval: false,
+      // Work offline-first so cached data renders instantly
+      networkMode: "offlineFirst",
       // 🔧 FIX: Reduce retry attempts to prevent retry loops
       retry: (failureCount, error) => {
         // Don't retry on 4xx errors except 408 (timeout) and 429 (rate limit)
@@ -65,6 +67,7 @@ const queryClient = new QueryClient({
     },
     mutations: {
       retry: false, // 🔧 FIX: Disable mutation retries to prevent loops
+      networkMode: "offlineFirst",
     },
   },
 });

--- a/frontend/src/pages/DeviceSelection.tsx
+++ b/frontend/src/pages/DeviceSelection.tsx
@@ -117,7 +117,7 @@ const DeviceSelection = () => {
               <Input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="Поиск приставки (например, Openbox, U2C, мо��ель)"
+                placeholder="Поиск приставки (например, Openbox, U2C, модель)"
                 className="pl-10 h-12 rounded-2xl border-gray-200 bg-white shadow-sm focus-visible:ring-2"
               />
             </div>


### PR DESCRIPTION
## Purpose

The user reported slow loading times for admin pages (/admin/tv-interfaces, /admin/remotes, /admin/steps-fixed, /admin/problems) and requested caching functionality to enable instant loading on subsequent visits and offline functionality when there's no internet connection. The goal is to cache data after the first load so users don't have to wait on repeat visits.

## Code changes

- **Backend search improvements**: Enhanced PostgreSQL full-text search in `Problem.js` to include device name, brand, and model fields for better search results
- **Frontend caching layer**: Added comprehensive caching system in API client with localStorage persistence for GET requests (4MB limit, 7-day TTL for offline usage)
- **Devices API caching**: Implemented cache-first strategy for all read operations (getDevices, getDevice, search, stats) with cache invalidation on write operations
- **Remotes API caching**: Added similar caching pattern for remotes with appropriate cache invalidation on mutations
- **Offline-first configuration**: Updated React Query to use `networkMode: "offlineFirst"` for both queries and mutations
- **Fallback mechanism**: Added offline cache fallback when network requests fail after retries
- **Minor fix**: Corrected typo in device search placeholder textTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dff8c208e75e4dc0ac2bbbc3df58daea/orbit-haven)

👀 [Preview Link](https://dff8c208e75e4dc0ac2bbbc3df58daea-orbit-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dff8c208e75e4dc0ac2bbbc3df58daea</projectId>-->
<!--<branchName>orbit-haven</branchName>-->