### PR TITLE
Add home button to admin login page

### DIFF
--- a/frontend/src/pages/admin/Login.tsx
+++ b/frontend/src/pages/admin/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -63,6 +63,9 @@ export default function AdminLogin() {
             {error && <div className="text-red-600 text-sm">{error}</div>}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? "Входим..." : "Войти"}
+            </Button>
+            <Button asChild variant="ghost" className="w-full mt-2">
+              <Link to="/">На главную</Link>
             </Button>
           </form>
         </CardContent>


### PR DESCRIPTION
## Purpose
The user requested to add a way to exit/navigate back to the main menu from the admin login page when the password is unknown. They wanted to ensure there's a clear path back to the homepage from the admin panel login screen.

## Code changes
- Added `Link` import from `react-router-dom` to the admin login component
- Added a "На главную" (Home) button below the login button that navigates back to the main page (`/`)
- Used ghost variant styling for the home button with full width and top marginTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/677b5ae7f09b4c8c970c3da29edb4eac/aura-home)

👀 [Preview Link](https://677b5ae7f09b4c8c970c3da29edb4eac-aura-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>677b5ae7f09b4c8c970c3da29edb4eac</projectId>-->
<!--<branchName>aura-home</branchName>-->